### PR TITLE
Allow aws client to be overriden

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -293,6 +293,11 @@ function get_attachment_labels( int $id ) : array {
  * @return \Aws\Rekognition\RekognitionClient
  */
 function get_rekognition_client() : RekognitionClient {
+	static $client;
+	if ( $client ) {
+		return $client;
+	}
+
 	$client_args = [
 		'version' => '2016-06-27',
 		'region'  => 'us-east-1',
@@ -315,9 +320,21 @@ function get_rekognition_client() : RekognitionClient {
 	 *
 	 * @param array $client_args Args used to instantiate the RekognitionClient
 	 */
-	$client_args = apply_filters( 'hm.aws.rekognition.client', $client_args );
+	$client_args = apply_filters( 'hm.aws.rekognition.client_args', $client_args );
 
-	return RekognitionClient::factory( $client_args );
+	/**
+	 * Modify the RekognitionClient client object.
+	 *
+	 * @param null  $client      The client object to override
+	 * @param array $client_args Args used to instantiate the RekognitionClient
+	 */
+	$client = apply_filters( 'hm.aws.rekognition.client', null, $client_args );
+	if ( $client ) {
+		return $client;
+	}
+
+	$client = RekognitionClient::factory( $client_args );
+	return $client;
 }
 
 /**

--- a/plugin.php
+++ b/plugin.php
@@ -7,7 +7,7 @@ use WP_CLI;
 /**
  * Name: AWS Rekognition
  * Plugin Author: Joe Hoyle | Human Made
- * Version: 0.1.2
+ * Version: 0.1.3
  */
 
 require __DIR__ . '/inc/namespace.php';


### PR DESCRIPTION
We want to be able to replace the client from `HM\Platform\get_aws_sdk()` from our module.