### PR TITLE
Fallback to sending image bytes if not in supported region

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -48,8 +48,30 @@ function fetch_data_for_attachment( int $id ) {
 	$file   = get_attached_file( $id );
 	$client = get_rekognition_client();
 
+	$region = $client->getRegion();
+
+	// Supported Rekognition regions.
+	$supported_regions = [
+		'us-east-1',
+		'us-east-2',
+		'us-west-2',
+		'eu-west-1',
+		'ap-south-1',
+		'ap-northeast-1',
+		'ap-northeast-2',
+		'ap-southeast-2',
+	];
+
+	/**
+	 * Pass the S3 object's bucket and location to the AWS Rekogition API, rather than sending the bytes over the wire.
+	 *
+	 * @param bool $use_s3_object_path
+	 * @param int  $id
+	 */
+	$use_s3_object_path = apply_filters( 'hm.aws.rekognition.use_s3_object_path', in_array( $region, $supported_regions, true ), $id );
+
 	// Set up image argument.
-	if ( preg_match( '#s3://(?P<bucket>[^/]+)/(?P<path>.*)#', $file, $matches ) ) {
+	if ( preg_match( '#s3://(?P<bucket>[^/]+)/(?P<path>.*)#', $file, $matches ) && $use_s3_object_path ) {
 		$image_args = [
 			'S3Object' => [
 				'Bucket' => $matches['bucket'],


### PR DESCRIPTION
Check if we should send the s3 object path to AWS Rekognition based off if the chosen region is supported.

Also pass this through a filter if someone wants to adjust the behaviour.

Supercedes #7