### PR TITLE
Fix supported region logic

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -353,6 +353,7 @@ function get_rekognition_client() : RekognitionClient {
 
 	// Ensure region is supported.
 	if ( ! in_array( $client_args['region'], get_supported_regions(), true ) ) {
+		trigger_error( sprintf( 'AWS Rekognition: The region %s is unsupported, falling back to "us-east-1"', $client_args['region'] ), E_USER_WARNING );
 		$client_args['region'] = 'us-east-1';
 	}
 


### PR DESCRIPTION
The logic around checking supported regions wasn't right unfortunately.

Actually fixes #6 

- We weren't checking the region set when creating the client so an unsupported region could be passed when relying on the instance profile
- Using the S3 object params requires that the Rekognition client has the same region as the S3 bucket

I think this fixes the root of the problem by adding in compatibility with S3 uploads for the default region and comparing rekog client region to S3 region.

This relies on using S3 uploads, or at least having `S3_UPLOADS_REGION` defined, if we were to avoid that requirement however a more robust solution would be to check the bucket region based on the given attachment file URL but that's not 100% either. Thoughts?