### PR TITLE
Fix: Don't override fields added to media edit screen.

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -23,13 +23,13 @@ function attachment_fields( $fields, WP_Post $post ) {
 		return $fields;
 	}
 
-	$form_fields['hm-aws-rekognition-labels'] = [
+	$fields['hm-aws-rekognition-labels'] = [
 		'label' => __( 'Detected Image labels', 'hm-aws-rekognition' ),
 		'input' => 'html',
 		'html'  => get_keywords_html( $post->ID ),
 	];
 
-	return $form_fields;
+	return $fields;
 }
 
 function get_keywords_html( $post_id, $limit = 10 ) : string {


### PR DESCRIPTION
by other plugins using the filter `attachment_fields_to_edit`

Fixes #20 