### PR TITLE
Improve error display in the admin

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -11,6 +11,9 @@ function bootstrap() {
 }
 
 function output_metabox( WP_Post $post ) {
+	if ( ! wp_attachment_is_image( $post->ID ) ) {
+		return;
+	}
 	echo get_keywords_html( $post->ID, 20 );
 }
 
@@ -20,6 +23,11 @@ function attachment_fields( $fields, WP_Post $post ) {
 
 	// We use a metabox on the attachment edit screen.
 	if ( $action === 'edit' && intval( $post_id ) === $post->ID ) {
+		return $fields;
+	}
+
+	// Check attachment type.
+	if ( ! wp_attachment_is_image( $post->ID ) ) {
 		return $fields;
 	}
 
@@ -43,11 +51,8 @@ function get_keywords_html( $post_id, $limit = 10 ) : string {
 				'<style>
 					.compat-field-hm-aws-rekognition-labels p { margin: 6px 0; }
 				</style>
-				<p>%s</p>
-				<p class="error message">%s: %s</p>',
-				esc_html__( 'There was an error analysing the image.', 'hm-aws-rekognition' ),
-				esc_html( (string) $label_errors->get_error_code() ),
-				esc_html( $label_errors->get_error_message() ?? 'Unspecified error' )
+				<p>%s</p>',
+				esc_html__( 'There was an error analysing the image. Check the error log for details.', 'hm-aws-rekognition' )
 			);
 		}
 

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -14,6 +14,7 @@ function output_metabox( WP_Post $post ) {
 	if ( ! wp_attachment_is_image( $post->ID ) ) {
 		return;
 	}
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo get_keywords_html( $post->ID, 20 );
 }
 
@@ -52,7 +53,7 @@ function get_keywords_html( $post_id, $limit = 10 ) : string {
 					.compat-field-hm-aws-rekognition-labels p { margin: 6px 0; }
 				</style>
 				<p>%s</p>',
-				esc_html__( 'There was an error analysing the image. Check the error log for details.', 'hm-aws-rekognition' )
+				esc_html__( 'There was an error analyzing the image.', 'hm-aws-rekognition' )
 			);
 		}
 
@@ -63,7 +64,7 @@ function get_keywords_html( $post_id, $limit = 10 ) : string {
 				.compat-field-hm-aws-rekognition-labels p { margin: 6px 0; }
 			</style>
 			<p><span class="spinner is-active"></span> %s</p>',
-			esc_html__( 'Analysing...', 'hm-aws-rekognition' )
+			esc_html__( 'Analyzing...', 'hm-aws-rekognition' )
 		);
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -73,6 +73,7 @@ function fetch_data_for_attachment( int $id ) {
 		];
 	} else {
 		$image_args = [
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			'Bytes' => file_get_contents( $file ),
 		];
 	}
@@ -99,6 +100,7 @@ function fetch_data_for_attachment( int $id ) {
 
 			$responses['labels'] = $labels_response['Labels'];
 		} catch ( Exception $e ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			trigger_error( $e->getMessage(), E_USER_WARNING );
 			$responses['labels'] = new WP_Error( 'aws-rekognition-error', $e->getMessage() );
 		}
@@ -123,6 +125,7 @@ function fetch_data_for_attachment( int $id ) {
 
 			$responses['moderation'] = $moderation_response['ModerationLabels'];
 		} catch ( Exception $e ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			trigger_error( $e->getMessage(), E_USER_WARNING );
 			$responses['moderation'] = new WP_Error( 'aws-rekognition-error', $e->getMessage() );
 		}
@@ -145,6 +148,7 @@ function fetch_data_for_attachment( int $id ) {
 
 			$responses['faces'] = $faces_response['FaceDetails'];
 		} catch ( Exception $e ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			trigger_error( $e->getMessage(), E_USER_WARNING );
 			$responses['faces'] = new WP_Error( 'aws-rekognition-error', $e->getMessage() );
 		}
@@ -166,6 +170,7 @@ function fetch_data_for_attachment( int $id ) {
 
 			$responses['celebrities'] = $celebrities_response['CelebrityFaces'];
 		} catch ( Exception $e ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			trigger_error( $e->getMessage(), E_USER_WARNING );
 			$responses['celebrities'] = new WP_Error( 'aws-rekognition-error', $e->getMessage() );
 		}
@@ -187,6 +192,7 @@ function fetch_data_for_attachment( int $id ) {
 
 			$responses['text'] = $text_response['TextDetections'];
 		} catch ( Exception $e ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			trigger_error( $e->getMessage(), E_USER_WARNING );
 			$responses['text'] = new WP_Error( 'aws-rekognition-error', $e->getMessage() );
 		}
@@ -357,6 +363,7 @@ function get_rekognition_client() : RekognitionClient {
 
 	// Ensure region is supported.
 	if ( ! in_array( $client_args['region'], get_supported_regions(), true ) ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		trigger_error( sprintf( 'AWS Rekognition: The region %s is unsupported, falling back to "us-east-1"', $client_args['region'] ), E_USER_WARNING );
 		$client_args['region'] = 'us-east-1';
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -100,7 +100,7 @@ function fetch_data_for_attachment( int $id ) {
 			$responses['labels'] = $labels_response['Labels'];
 		} catch ( Exception $e ) {
 			trigger_error( $e->getMessage(), E_USER_WARNING );
-			$responses['labels'] = new WP_Error( 'aws-error', $e->getMessage() );
+			$responses['labels'] = new WP_Error( 'aws-rekognition-error', $e->getMessage() );
 		}
 	}
 
@@ -123,7 +123,8 @@ function fetch_data_for_attachment( int $id ) {
 
 			$responses['moderation'] = $moderation_response['ModerationLabels'];
 		} catch ( Exception $e ) {
-			$responses['moderation'] = new WP_Error( 'aws-error', $e->getMessage() );
+			trigger_error( $e->getMessage(), E_USER_WARNING );
+			$responses['moderation'] = new WP_Error( 'aws-rekognition-error', $e->getMessage() );
 		}
 	}
 
@@ -144,7 +145,8 @@ function fetch_data_for_attachment( int $id ) {
 
 			$responses['faces'] = $faces_response['FaceDetails'];
 		} catch ( Exception $e ) {
-			$responses['faces'] = new WP_Error( 'aws-error', $e->getMessage() );
+			trigger_error( $e->getMessage(), E_USER_WARNING );
+			$responses['faces'] = new WP_Error( 'aws-rekognition-error', $e->getMessage() );
 		}
 	}
 
@@ -164,7 +166,8 @@ function fetch_data_for_attachment( int $id ) {
 
 			$responses['celebrities'] = $celebrities_response['CelebrityFaces'];
 		} catch ( Exception $e ) {
-			$responses['celebrities'] = new WP_Error( 'aws-error', $e->getMessage() );
+			trigger_error( $e->getMessage(), E_USER_WARNING );
+			$responses['celebrities'] = new WP_Error( 'aws-rekognition-error', $e->getMessage() );
 		}
 	}
 
@@ -184,7 +187,8 @@ function fetch_data_for_attachment( int $id ) {
 
 			$responses['text'] = $text_response['TextDetections'];
 		} catch ( Exception $e ) {
-			$responses['text'] = new WP_Error( 'aws-error', $e->getMessage() );
+			trigger_error( $e->getMessage(), E_USER_WARNING );
+			$responses['text'] = new WP_Error( 'aws-rekognition-error', $e->getMessage() );
 		}
 	}
 


### PR DESCRIPTION
Dumping out the full AWS error message doesnt make a nice user experience. This leaves a user friendly message and ensure the full error is available in the error logs.

Fixes #18