### PR TITLE
Update media modal periodically for new uploads

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -47,7 +47,7 @@ function get_keywords_html( $post_id, $limit = 10 ) : string {
 	if ( empty( $labels ) ) {
 		// Check if an error was returned.
 		$label_errors = get_post_meta( $post_id, 'hm_aws_rekognition_error_labels', true );
-		if ( is_wp_error( $label_errors ) ) {
+		if ( ! empty( $label_errors ) ) {
 			return sprintf(
 				'<style>
 					.compat-field-hm-aws-rekognition-labels p { margin: 6px 0; }
@@ -63,8 +63,19 @@ function get_keywords_html( $post_id, $limit = 10 ) : string {
 				.compat-field-hm-aws-rekognition-labels .spinner { float: none; margin: -2px 5px 0 0; }
 				.compat-field-hm-aws-rekognition-labels p { margin: 6px 0; }
 			</style>
-			<p><span class="spinner is-active"></span> %s</p>',
-			esc_html__( 'Analyzing...', 'hm-aws-rekognition' )
+			<p><span class="spinner is-active"></span> %1$s</p>
+			<script>
+				( function () {
+					setTimeout( function () {
+						wp.media.model.Attachment.get( %2$d ).fetch();
+					}, 5000 );
+					jQuery( document ).on( \'heartbeat-tick\', function ( event, data ) {
+						wp.media.model.Attachment.get( %2$d ).fetch();
+					} );
+				} )();
+			</script>',
+			esc_html__( 'Analyzing...', 'hm-aws-rekognition' ),
+			$post_id
 		);
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -33,8 +33,8 @@ function on_update_attachment_metadata( array $data, int $id ) : array {
 		return $data;
 	}
 
-	$image_types = [ IMAGETYPE_GIF, IMAGETYPE_JPEG, IMAGETYPE_PNG, IMAGETYPE_BMP ];
-	$mime        = exif_imagetype( get_attached_file( $id ) );
+	$image_types = [ "image/jpeg", "image/png" ];
+	$mime = get_post_mime_type( $id );
 	if ( ! in_array( $mime, $image_types, true ) ) {
 		return $data;
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -33,7 +33,8 @@ function on_update_attachment_metadata( array $data, int $id ) : array {
 		return $data;
 	}
 
-	$image_types = [ "image/jpeg", "image/png" ];
+	// Rekognition only supports JPEG and PNG.
+	$image_types = [ 'image/jpeg', 'image/png' ];
 	$mime = get_post_mime_type( $id );
 	if ( ! in_array( $mime, $image_types, true ) ) {
 		return $data;


### PR DESCRIPTION
When the media attachment meta is showing the analysing spinner we can set WordPress up to periodically refresh the attachment model. This will update the UI once the label data has been returned or if an error occurs.

Any modifications to the fields like alt text etc do not get wiped out by doing this.