### PR TITLE
Hotfix: Remove Labels polling from Attachment Details view

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -72,17 +72,7 @@ function get_keywords_html( $post_id, $limit = 10 ) : string {
 				.compat-field-hm-aws-rekognition-labels .spinner { float: none; margin: -2px 5px 0 0; }
 				.compat-field-hm-aws-rekognition-labels p { margin: 6px 0; }
 			</style>
-			<p><span class="spinner is-active"></span> %1$s</p>
-			<script>
-				( function () {
-					setTimeout( function () {
-						wp.media.model.Attachment.get( %2$d ).fetch();
-					}, 5000 );
-					jQuery( document ).on( \'heartbeat-tick\', function ( event, data ) {
-						wp.media.model.Attachment.get( %2$d ).fetch();
-					} );
-				} )();
-			</script>',
+			<p><span class="spinner is-active"></span> %1$s</p>',
 			esc_html__( 'Analyzing...', 'hm-aws-rekognition' ),
 			$post_id
 		);


### PR DESCRIPTION
This is implented a bit too naively, which means a _very large_ amount of admin-ajax requests can be sent when images don't have labels (perhaps imported images, or just uploaded images). If images are uploaded, or when an attachment detail is opened for any image without labels, it's going to queue a `.fetch()` every time heartbeat happens.

There would need to be some stop clause for this to be implemented in the future. I.e. once the labels are populated then polling stops, and / or polling only happens as long as the media details are open. Either way, that's more of a complex solution, and in the short term it's best to disable the auto-polling.
